### PR TITLE
Fix formatting of ASCII logo in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-`/-+-+-+ +-+-+-+-+-+-+-\`
-`|G|E|M| |W|A|R|R|I|O|R|`
-`\-+-+-+ +-+-+-+-+-+-+-/`
+```
+/-+-+-+ +-+-+-+-+-+-+-\
+|G|E|M| |W|A|R|R|I|O|R|
+\-+-+-+ +-+-+-+-+-+-+-/
+```
 <small>logo courtesy of [ascii generator](http://www.network-science.de/ascii/)</small>
 
 **Gem Warrior** is a text adventure that takes place in the land of **Jool**, where randomized fortune is just as likely as *mayhem*.


### PR DESCRIPTION
This patch uses a code block for the project's ASCII logo in the README so it appears properly when browsing the repo on GitHub. (Currently it uses three inline code spans and the line breaks are lost.)
